### PR TITLE
Remove obsolete `WITH_OMX` build option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN ln -s /opt/janus/include/janus /usr/include/janus && \
 
 RUN git clone --depth=1 https://github.com/pikvm/ustreamer && \
     cd ustreamer && \
-    make WITH_OMX=1 WITH_JANUS=1 && \
+    make WITH_JANUS=1 && \
     mv /ustreamer/janus/libjanus_ustreamer.so /opt/janus/lib/janus/plugins/libjanus_ustreamer.so
 
 COPY janus.plugin.ustreamer.jcfg /opt/janus/lib/janus/configs/janus.plugin.ustreamer.jcfg


### PR DESCRIPTION
uStreamer doesn’t offer the `WITH_OMX` option anymore, so we don’t need to specify it.

I’ve built this image on the device and ran it, and it worked the same as our previous one (`tinypilotkvm/janus:2022-03-07`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/janus-docker/2)
<!-- Reviewable:end -->
